### PR TITLE
feat: support s3ForcePathStyle in configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,4 +22,5 @@ store:
     keyPrefix: some-prefix # optional, has the effect of nesting all files in a subdirectory
     region: us-west-2 # optional, will use aws s3's default behavior if not specified
     endpoint: https://{service}.{region}.amazonaws.com # optional, will use aws s3's default behavior if not specified
+    s3ForcePathStyle: false # optional, will use path style URLs for S3 objects
 ```

--- a/src/config.js
+++ b/src/config.js
@@ -5,4 +5,5 @@ export interface S3Config {
   keyPrefix: string;
   endpoint?: string;
   region?: string;
+  s3ForcePathStyle?: boolean;
 }

--- a/src/index.js
+++ b/src/index.js
@@ -25,7 +25,11 @@ export default class S3Database implements ILocalData {
     }
     const configKeyPrefix = this.config.keyPrefix;
     this.config.keyPrefix = configKeyPrefix != null ? (configKeyPrefix.endsWith('/') ? configKeyPrefix : `${configKeyPrefix}/`) : '';
-    this.s3 = new S3({ endpoint: this.config.endpoint, region: this.config.region });
+    this.s3 = new S3({
+      endpoint: this.config.endpoint,
+      region: this.config.region,
+      s3ForcePathStyle: this.config.s3ForcePathStyle
+    });
   }
 
   async getSecret(): Promise<any> {

--- a/src/s3PackageManager.js
+++ b/src/s3PackageManager.js
@@ -22,7 +22,11 @@ export default class S3PackageManager implements ILocalPackageManager {
     this.config = config;
     this.packageName = packageName;
     this.logger = logger;
-    this.s3 = new S3({ endpoint: config.endpoint, region: config.region });
+    this.s3 = new S3({
+      endpoint: this.config.endpoint,
+      region: this.config.region,
+      s3ForcePathStyle: this.config.s3ForcePathStyle
+    });
   }
 
   updatePackage(name: string, updateHandler: Callback, onWrite: Callback, transformPackage: Function, onEnd: Callback) {


### PR DESCRIPTION
When using some s3-compatible services (i.e., https://localstack.cloud/), it is often necessary to configure the S3 client to use the path form `{endpoint}/{bucketname}` for S3 object URLs, as the default subdomain form `{bucketname}.{service}.{region}` won't work.

This PR simply expands the exposed plugin config to convey the optional `s3ForcePathStyle` option to the S3 client.