### PR TITLE
Handle errors when JSON.parse fails on S3 response

### DIFF
--- a/src/s3PackageManager.js
+++ b/src/s3PackageManager.js
@@ -58,7 +58,13 @@ export default class S3PackageManager implements ILocalPackageManager {
             reject(convertS3Error(err));
             return;
           }
-          const data = JSON.parse(response.Body.toString());
+          let data;
+          try {
+            data = JSON.parse(response.Body.toString());
+          } catch (e) {
+            reject(e);
+            return;
+          }
           resolve(data);
         }
       );


### PR DESCRIPTION
Just a small code cleanup. An error thrown by JSON.parse here will be an uncaught exception and kill the entire `verdaccio` process. By properly rejecting the promise, only the single request that triggered the error will fail with a 500.

An alternative option here would be to, upon detecting invalid data in S3, to return a `create404Error()` (which will signal to verdaccio to redownload the package from upstream). But that feels like it needs more thought.

I ran into this when using this plugin without a keyPrefix and trying to install https://www.npmjs.com/package/soap which ran into this issue: https://github.com/aws/aws-sdk-js/issues/2302 So this plugin was trying to store/read an object at `soap/package.json`; which failed in unusual ways. I'd suggest either making `keyPrefix` required or passing `s3ForcePathStyle: true` as an S3 option.