### PR TITLE
chore: build fails if lib does not exist

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "npm run flow && eslint .",
     "commitmsg": "commitlint -e $GIT_PARAMS",
     "flow": "flow",
-    "build": "rm -r lib/ && babel src/ --out-dir lib/ --copy-files --ignore ___tests___",
+    "build": "babel src/ --out-dir lib/ --copy-files --ignore ___tests___",
     "watch": "babel --source-maps --watch src/ --out-dir lib/ --copy-files --ignore ___tests___",
     "prepublish": "npm run build",
     "format": "prettier --single-quote --trailing-comma none --write \"{src,test}/**/*.js\"",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "npm run flow && eslint .",
     "commitmsg": "commitlint -e $GIT_PARAMS",
     "flow": "flow",
-    "build": "babel src/ --out-dir lib/ --copy-files --ignore ___tests___",
+    "build": "rm -rf lib/ && babel src/ --out-dir lib/ --copy-files --ignore ___tests___",
     "watch": "babel --source-maps --watch src/ --out-dir lib/ --copy-files --ignore ___tests___",
     "prepublish": "npm run build",
     "format": "prettier --single-quote --trailing-comma none --write \"{src,test}/**/*.js\"",


### PR DESCRIPTION
**Type:** bug

**Description:**

On install packages for development fails, lib should not be removed, it will override files anyway.
