### PR TITLE
fix: if status code is 404 stream will fails by his own

### DIFF
--- a/src/s3PackageManager.js
+++ b/src/s3PackageManager.js
@@ -237,21 +237,22 @@ export default class S3PackageManager implements ILocalPackageManager {
         // verdaccio force garbage collects a stream on 404, so we can't emit more
         // than one error or it'll fail
         // https://github.com/verdaccio/verdaccio/blob/c1bc261/src/lib/storage.js#L178
+        if (statusCode !== 404) {
+          if (headers['content-length']) {
+            const contentLength = parseInt(headers['content-length'], 10);
 
-        if (headers['content-length']) {
-          const contentLength = parseInt(headers['content-length'], 10);
+            // not sure this is necessary
+            if (headersSent) {
+              console.log('********* headers already sent');
+              return;
+            }
 
-          // not sure this is necessary
-          if (headersSent) {
-            console.log('********* headers already sent');
-            return;
+            headersSent = true;
+
+            readTarballStream.emit('content-length', contentLength);
+            // we know there's content, so open the stream
+            readTarballStream.emit('open');
           }
-
-          headersSent = true;
-
-          readTarballStream.emit('content-length', contentLength);
-          // we know there's content, so open the stream
-          readTarballStream.emit('open');
         }
       })
       .createReadStream();


### PR DESCRIPTION
**Type:** bug

**Description:**

This is an issue I solved on Google Cloud Plugin where if we open the stream verdaccio won't try to get it from upstream
As a reference https://github.com/verdaccio/verdaccio-google-cloud/blob/master/src/storage.js#L308

If the resource is not found, the stream will emit an error anyway, so, **we should not open the stream if we know the resource is not there**, in such case we wait the stream fails and verdaccio takes the control of the error and fetch the tarball, otherwise, we doom the user to get 404. 

Here is were the error event is emitted. 
https://github.com/aws/aws-sdk-js/blob/fe88308a8699b39aef06492c898b265a3a24251f/lib/request.js#L38

