### PR TITLE
support private s3 bucket

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -6,4 +6,6 @@ export interface S3Config {
   endpoint?: string;
   region?: string;
   s3ForcePathStyle?: boolean;
+  accessKeyId?: string;
+  secretAccessKey?: string;
 }

--- a/src/index.js
+++ b/src/index.js
@@ -25,11 +25,21 @@ export default class S3Database implements ILocalData {
     }
     const configKeyPrefix = this.config.keyPrefix;
     this.config.keyPrefix = configKeyPrefix != null ? (configKeyPrefix.endsWith('/') ? configKeyPrefix : `${configKeyPrefix}/`) : '';
-    this.s3 = new S3({
-      endpoint: this.config.endpoint,
-      region: this.config.region,
-      s3ForcePathStyle: this.config.s3ForcePathStyle
-    });
+    if(this.config.accessKeyId&&this.secretAccessKey){
+      this.s3 = new S3({
+        endpoint: this.config.endpoint,
+        region: this.config.region,
+        s3ForcePathStyle: this.config.s3ForcePathStyle,
+        accessKeyId: this.config.accessKeyId,
+        secretAccessKey: this.config.secretAccessKey
+      });
+    }else{
+      this.s3 = new S3({
+        endpoint: this.config.endpoint,
+        region: this.config.region,
+        s3ForcePathStyle: this.config.s3ForcePathStyle
+      });
+    }
   }
 
   async getSecret(): Promise<any> {

--- a/src/s3PackageManager.js
+++ b/src/s3PackageManager.js
@@ -22,11 +22,21 @@ export default class S3PackageManager implements ILocalPackageManager {
     this.config = config;
     this.packageName = packageName;
     this.logger = logger;
-    this.s3 = new S3({
-      endpoint: this.config.endpoint,
-      region: this.config.region,
-      s3ForcePathStyle: this.config.s3ForcePathStyle
-    });
+    if(this.config.accessKeyId&&this.secretAccessKey){
+      this.s3 = new S3({
+        endpoint: this.config.endpoint,
+        region: this.config.region,
+        s3ForcePathStyle: this.config.s3ForcePathStyle,
+        accessKeyId: this.config.accessKeyId,
+        secretAccessKey: this.config.secretAccessKey
+      });
+    }else{
+      this.s3 = new S3({
+        endpoint: this.config.endpoint,
+        region: this.config.region,
+        s3ForcePathStyle: this.config.s3ForcePathStyle
+      });
+    }
   }
 
   updatePackage(name: string, updateHandler: Callback, onWrite: Callback, transformPackage: Function, onEnd: Callback) {


### PR DESCRIPTION
modify S3Config to support private s3 bucket.
```
export interface S3Config {
  bucket: string;
  keyPrefix: string;
  endpoint?: string;
  region?: string;
  s3ForcePathStyle?: boolean;
  accessKeyId?: string;
  secretAccessKey?: string;
}
```

set up accessKeyId and secretAccessKey from config.