### PR TITLE
fix: does not emit tarball stream open when file not found

### DIFF
--- a/src/___tests___/__snapshots__/s3PackageManager.test.js.snap
+++ b/src/___tests___/__snapshots__/s3PackageManager.test.js.snap
@@ -132,7 +132,7 @@ Array [
   },
   Object {
     "Key": "/write-storage/new-readme-0.0.0.tgz",
-    "Size": 0,
+    "Size": 352,
   },
 ]
 `;

--- a/src/___tests___/s3PackageManager.test.js
+++ b/src/___tests___/s3PackageManager.test.js
@@ -245,6 +245,10 @@ describe('S3 package manager', () => {
       const packageManager = new S3PackageManager(config, 'readme-test', logger);
       const readTarballStream = packageManager.readTarball('file-does-not-exist-0.0.0.tgz');
 
+      readTarballStream.on('data', data => {
+        expect(data).not.toBeDefined();
+      });
+
       readTarballStream.on('error', function(err) {
         expect(err).toBeTruthy();
         done();

--- a/src/s3PackageManager.js
+++ b/src/s3PackageManager.js
@@ -240,7 +240,7 @@ export default class S3PackageManager implements ILocalPackageManager {
         // than one error or it'll fail
         // https://github.com/verdaccio/verdaccio/blob/c1bc261/src/lib/storage.js#L178
 
-        if (headers['content-length']) {
+        if (statusCode !== 404 && headers['content-length']) {
           const contentLength = parseInt(headers['content-length'], 10);
 
           // not sure this is necessary


### PR DESCRIPTION
**Bug:**

The following has been addressed in the PR:

*  [S3 proxying isn't working out of the box, there is a bugfix on verdaccio only repo??](https://github.com/Remitly/verdaccio-s3-storage/issues/26)
*  Updated tests

I've updated the tests and applied the fix mentioned in the above issue, but embarrassingly I don't know how to actually run this locally to be able to do an end to end test.  I don't have much experience with NodeJs.

If somebody can advise, then I'll be happy to do further testing.